### PR TITLE
Updated terminology

### DIFF
--- a/backend/templates/dashboard/posters/list.twig
+++ b/backend/templates/dashboard/posters/list.twig
@@ -72,7 +72,7 @@
                                         {% endif %}
 
                                         {% if group.canEdit %}
-                                            <div>Views: {{ poster.views }}</div>
+                                            <div title="Each time a poster is served, a hit is recorded.">Hits: {{ poster.views }}</div>
 
                                             <div class="btn-group btn-group-sm mt-2">
                                                 <a href="{{ urlFor('dashboard:posters:edit', {id: poster.id}) }}"


### PR DESCRIPTION
Updated the terminology for the hit counter to read "hits" instead of views, and added a div Title to create a tooltip that explains hits when you hover the term.